### PR TITLE
Replace deprecated 'onAfterSetupMiddleware' and 'onBeforeSetupMiddleware' options

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "setupMiddlewares": "react-scripts setupMiddlewares"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Replace 'onAfterSetupMiddleware' and 'onBeforeSetupMiddleware' options with 'setupMiddlewares' option in `package.json`.

* Add "setupMiddlewares": "react-scripts setupMiddlewares" to the `scripts` section in `package.json`
