### PR TITLE
Add interview prompt and skill and role to multimodal

### DIFF
--- a/src/components/control-tray/ConnectButton.tsx
+++ b/src/components/control-tray/ConnectButton.tsx
@@ -6,15 +6,23 @@ type ConnectButtonProps = {
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
   className?: string; // Add className to the props
+  role: string;
+  skillLevel: string;
 };
 
 const ConnectButton = forwardRef<HTMLButtonElement, ConnectButtonProps>(
-  ({ connected, connect, disconnect, className = '' }, ref) => {
+  ({ connected, connect, disconnect, className = '', role, skillLevel }, ref) => {
+    const handleConnect = async () => {
+      await connect();
+      // Call sendInitialPrompt with role and skillLevel
+      sendInitialPrompt(role, skillLevel);
+    };
+
     return (
       <button
         ref={ref}
         className={`control-button control-button-connect ${connected ? '' : 'disconnected'} ${className}`}
-        onClick={connected ? disconnect : connect}
+        onClick={connected ? disconnect : handleConnect}
       >
         {connected ? <Pause /> : <Play />}
       </button>

--- a/src/components/control-tray/VideoControlTray.tsx
+++ b/src/components/control-tray/VideoControlTray.tsx
@@ -32,6 +32,8 @@ const VideoControlTray: React.FC<VideoControlTrayProps> = ({
   const [muted, setMuted] = useState(false);
   const renderCanvasRef = useRef<HTMLCanvasElement>(null);
   const connectButtonRef = useRef<HTMLButtonElement>(null);
+  const [role, setRole] = useState<string>('');
+  const [skillLevel, setSkillLevel] = useState<string>('');
 
   const { client, connected, connect, disconnect, volume } = useLiveAPIContext();
   const handleStreamChange = useHandleStreamChange(videoStreams, setActiveVideoStream, onVideoStreamChange);
@@ -143,6 +145,8 @@ const VideoControlTray: React.FC<VideoControlTrayProps> = ({
           connected={connected}
           connect={connect}
           disconnect={disconnect}
+          role={role}
+          skillLevel={skillLevel}
         />
         {connected && <Radio className="streaming-status" />}
       </nav>

--- a/src/hooks/use-live-api.ts
+++ b/src/hooks/use-live-api.ts
@@ -13,7 +13,7 @@ export type UseLiveAPIResults = {
   setConfig: (config: LiveConfig) => void;
   config: LiveConfig;
   connected: boolean;
-  connect: () => Promise<void>;
+  connect: (role: string, skillLevel: string) => Promise<void>;
   disconnect: () => Promise<void>;
   volume: number;
   sendInterviewData: (data: any) => void;
@@ -79,7 +79,7 @@ export function useLiveAPI({
     };
   }, [client]);
 
-  const connect = useCallback(async () => {
+  const connect = useCallback(async (role: string, skillLevel: string) => {
     try {
       if (!config) {
         throw new Error("Config has not been set");
@@ -87,6 +87,7 @@ export function useLiveAPI({
       client.disconnect();
       await client.connect(config);
       setConnected(true);
+      sendInitialPrompt(role, skillLevel);
     } catch (error) {
       console.error("Error connecting to client:", error);
     }


### PR DESCRIPTION
Add functionality to send interview prompt, skill, and role to multimodal when connect button is clicked.

* **ConnectButton Component**:
  - Add `role` and `skillLevel` props.
  - Update `connect` function to call `sendInitialPrompt` with `role` and `skillLevel`.
  - Update `onClick` handler to use `handleConnect` function.

* **VideoControlTray Component**:
  - Add `role` and `skillLevel` state variables.
  - Pass `role` and `skillLevel` as props to `ConnectButton` component.

* **use-live-api Hook**:
  - Update `connect` function to accept `role` and `skillLevel` parameters.
  - Call `sendInitialPrompt` with `role` and `skillLevel` in the `connect` function.

