### PR TITLE
Fix connect button and video control tray

### DIFF
--- a/src/components/control-tray/ConnectButton.tsx
+++ b/src/components/control-tray/ConnectButton.tsx
@@ -1,9 +1,10 @@
 import React, { forwardRef } from 'react';
 import { Pause, Play } from 'lucide-react';
+import { useLiveAPIContext } from '../../contexts/LiveAPIContext';
 
 type ConnectButtonProps = {
   connected: boolean;
-  connect: () => Promise<void>;
+  connect: (role: string, skillLevel: string) => Promise<void>;
   disconnect: () => Promise<void>;
   className?: string; // Add className to the props
   role: string;
@@ -12,8 +13,10 @@ type ConnectButtonProps = {
 
 const ConnectButton = forwardRef<HTMLButtonElement, ConnectButtonProps>(
   ({ connected, connect, disconnect, className = '', role, skillLevel }, ref) => {
+    const { sendInitialPrompt } = useLiveAPIContext();
+
     const handleConnect = async () => {
-      await connect();
+      await connect(role, skillLevel);
       // Call sendInitialPrompt with role and skillLevel
       sendInitialPrompt(role, skillLevel);
     };

--- a/src/components/control-tray/VideoControlTray.tsx
+++ b/src/components/control-tray/VideoControlTray.tsx
@@ -143,7 +143,7 @@ const VideoControlTray: React.FC<VideoControlTrayProps> = ({
         <ConnectButton
           ref={connectButtonRef}
           connected={connected}
-          connect={connect}
+          connect={() => connect(role, skillLevel)}
           disconnect={disconnect}
           role={role}
           skillLevel={skillLevel}


### PR DESCRIPTION
Fix compilation errors in `ConnectButton.tsx` and `VideoControlTray.tsx`.

* **ConnectButton.tsx**
  - Import `sendInitialPrompt` from `useLiveAPIContext`.
  - Update `connect` prop to accept `role` and `skillLevel` parameters.
  - Call `sendInitialPrompt` with `role` and `skillLevel` in `handleConnect`.

* **VideoControlTray.tsx**
  - Pass `role` and `skillLevel` to `connect` in `ConnectButton`.

